### PR TITLE
Review and update of the landing page and the features archive

### DIFF
--- a/features/archive.html
+++ b/features/archive.html
@@ -136,8 +136,7 @@
                                     <p><a href="https://app.swaggerhub.com/apis/cportele/opf-features-api/1.0.0"
                                           target="_blank">Features API extended with Styles API</a> <strong>draft</strong>
                                         on SwaggerHub</p>
-                                </li>
-                                <li><a href="http://schemas.opengis.net/ogcapi/features" target="_blank">Schema Repository</a></li>                                
+                                </li>                                
                             </ul>
                         </div>
                     </li>

--- a/index.html
+++ b/index.html
@@ -141,7 +141,7 @@
             <h5 class="card-title">Next OGC API Virtual Code Sprint scheduled for July 12 to 14, 2022</h5>
             <p class="card-text">The Open Geospatial Consortium (OGC) invites software developers to the <strong>July 2022 OGC API Virtual Code Sprint - the Vector Data Code Sprint</strong>, to be held from July 12-14, 2022, with a pre-event webinar on June 30. Registration closes July 12.</p>
             <br/>
-            <p class="card-text">The Sprint will focus on all parts of OGC API Moving Features, OGC API Routes, OGC API 3D GeoVolumes, OGC API Features, and OGC API Joins. Each of these candidate and approved Standards provides a web interface to access some kind of partitioning of space.</p>
+            <p class="card-text">The Sprint will focus on all parts of OGC API Moving Features, OGC API Routes, OGC API 3D GeoVolumes, and OGC API Features.</p>
             <br/>
             <p class="card-text">For more information visit the <a href=" https://developer.ogc.org/sprints/17" target="_blank">Code Sprint website.</a> </p>
             <br/>
@@ -312,7 +312,9 @@
       <div class="col-lg-12 text-center">
         <p>&nbsp;</p>
         <h3 class="section-heading">Compliance Testing and Certification</h3>
-        <p>The executable test suite for Parts 1 and 2 of the OGC API - Features Standard is now available in the <a href="https://cite.ogc.org/te2/">OGC Validation beta environment</a>. More information about Compliance certification is on the <a href="https://www.ogc.org/compliance">OGC website</a>.</p>
+        <p>The executable test suite for Parts 1 and 2 of the <b>OGC API - Features Standard</b> is now <a href="https://cite.ogc.org/teamengine/">available</a>.</p>
+        <p>The executable test suite for the <b>OGC API - Environmental Data Retrieval Standard</b> is now <a href="https://cite.ogc.org/te2/">available</a> in Beta.</p>
+        <p>More information about Compliance certification is on the <a href="https://www.ogc.org/compliance">OGC website</a>.</p>
       </div>
     </div>
   </div>
@@ -342,7 +344,7 @@
               <div class="timeline-body">
                 <p class="text-muted">Find out more about <a href="https://developer.ogc.org/sprints/17/" target="_blank">this event</a> taking place on July 12-14.<br>
                   The code sprint begins at 05:00am EDT / 09:00am UTC on July 12, and ends at 03:30pm EDT/ 07:30pm UTC on July 14. .</p>
-                <p class="text-muted"><br/><a href="https://portal.ogc.org/public_ogc/register/220225asf_codesprint.php" target="_blank">Register Here</a> (closed)</p>
+                <p class="text-muted"><br/><a href="https://developer.ogc.org/sprints/17/" target="_blank">Register Here</a> (open)</p>
               </div>
             </div>
           </li>
@@ -358,7 +360,7 @@
               <div class="timeline-body">
                 <p class="text-muted"></p>
                 <p class="text-muted">This code sprint will take place in September 2022. The <b>tentative</b> dates are 14th to 16th of September. The <b>tentative</b> location is the Geovation Hub in London, UK. The code sprint will cover OGC API Records, ISO 19115, JSON-FG, and STAC. Hybrid event. </p>
-                <p class="text-muted"><br/><a href="https://www.ogc.org/projects/initiatives/ogcsprints" target="_blank">Registration is not currently open</a></p>
+                <p class="text-muted"><br/><a href="https://www.ogc.org/projects/initiatives/ogcsprints" target="_blank">Registration not yet open</a></p>
               </div>
             </div>
           </li>


### PR DESCRIPTION
**index.html**

- Removed OGC API Joins from July 2022 Code Sprint.
- Added ETS of OGC API EDR to the Compliance section.
- Updated registration link for the July 2022 Code Sprint.

**OGC API Features archive**

- Removes link to schema repository from the archive page. Reason: The schema repository is not archived. It is actually listed on the index.html page.