### PR TITLE
add MetOcean profiles to EDR/Maps pages

### DIFF
--- a/edr/index.html
+++ b/edr/index.html
@@ -166,6 +166,17 @@
                                 </div>
                             </div>
                             <div class="sect2">
+                                <h3 id="_profiles">Profiles</h3>
+                                <div class="paragraph">
+                                    <p>Profiles can be found at:</p>
+                                </div>
+                                <div class="ulist">
+                                    <ul>
+                                        <li><p><a href="https://docs.ogc.org/DRAFTS/26-027.html">MetOcean Profile for OGC API - Environmental Data Retrieval (draft)</a></p></li>
+                                    </ul>
+                                </div>
+                            </div>
+                            <div class="sect2">
                                 <h3 id="_development">Development</h3>
                                 <div class="paragraph">
                                     <p>Development of the standards takes place on <a

--- a/maps/index.html
+++ b/maps/index.html
@@ -152,6 +152,17 @@
                                 </div>
                             </div>
                             <div class="sect2">
+                                <h3 id="_profiles">Profiles</h3>
+                                <div class="paragraph">
+                                    <p>Profiles can be found at:</p>
+                                </div>
+                                <div class="ulist">
+                                    <ul>
+                                        <li><p><a href="https://docs.ogc.org/DRAFTS/26-002.html">MetOcean Profile for OGC API - Maps (draft)</a></p></li>
+                                    </ul>
+                                </div>
+                            </div>
+                            <div class="sect2">
                                 <h3 id="_development">Development</h3>
                                 <div class="paragraph">
                                     <p>Development of the standards takes place on <a


### PR DESCRIPTION
This PR adds a "Profile" section to both the [EDR](https://ogcapi.ogc.org/edr) and [Maps](https://ogcapi.ogc.org/maps) website pages for MetOcean profiles of same.

cc @solson-nws @chris-little @jerstlouis 